### PR TITLE
Helpful minq5 testing 

### DIFF
--- a/m/minq5/minqsw.m
+++ b/m/minq5/minqsw.m
@@ -47,7 +47,7 @@ ier=0;
 if size(G,2)~=n, 
 ier=-1;disp('minq: Hessian has wrong dimension');
 end;
-if all(all(abs(G - G') <= 1e-12))  
+if ~all(all(abs(G - G') <= 1e-12))  
 ier=-1;disp('minq: Hessian is not symmetric');
 end
 if size(c,1)~=n || size(c,2)~=1, 

--- a/m/minq5/minqsw.m
+++ b/m/minq5/minqsw.m
@@ -46,9 +46,10 @@ n=size(G,1);
 ier=0;
 if size(G,2)~=n, 
 ier=-1;disp('minq: Hessian has wrong dimension');
-x=NaN+zeros(n,1);fct=NaN;nsub=-1;
-return;
 end;
+if all(all(abs(G - G') <= 1e-8))  
+ier=-1;disp('minq: Hessian is not symmetric');
+end
 if size(c,1)~=n || size(c,2)~=1, 
 ier=-1;disp('minq: linear term has wrong dimension');
 end;

--- a/m/minq5/minqsw.m
+++ b/m/minq5/minqsw.m
@@ -47,7 +47,7 @@ ier=0;
 if size(G,2)~=n, 
 ier=-1;disp('minq: Hessian has wrong dimension');
 end;
-if all(all(abs(G - G') <= 1e-8))  
+if all(all(abs(G - G') <= 1e-12))  
 ier=-1;disp('minq: Hessian is not symmetric');
 end
 if size(c,1)~=n || size(c,2)~=1, 

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -63,11 +63,9 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     if G.shape[1] != n:
         ier = -1
         print("minq: Hessian has wrong dimension")
-        x = NaN + np.zeros(n)
-        fct = NaN
-        nsub = -1
-        return x, fct, ier, nsub
-
+    if not np.allclose(G, G.T, rtol=1e-12, atol=1e-12):
+        ier = -1
+        print("minq: Hessian is not symmetric")
     if c.shape[0] != n or c.shape[1] != 1:
         ier = -1
         print("minq: linear term has wrong dimension")
@@ -82,8 +80,8 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
             ier = -1
             print("minq: starting point has wrong dimension")
     if ier == -1:
-        x = NaN + zeros(n)
-        fct = NaN
+        x = np.NaN + np.zeros(n)
+        fct = np.NaN
         nsub = -1
         return x, fct, ier, nsub
 


### PR DESCRIPTION
This PR
- tests for symmetry in the Hessian matrix
- has an np.NaN bugfix
- simplifies (one clause) when ierr =-1

