### PR TITLE
Fixing python translation error for minq5

### DIFF
--- a/py/minq5/ldlup.py
+++ b/py/minq5/ldlup.py
@@ -36,7 +36,7 @@ def ldlup(L, d, j, g):
         v = np.zeros((0, 1))
         del_ = g[j]
         if del_ <= n * eps:
-            p = np.eye(n)[:, 0]
+            p = np.eye(n)[:, [0]]
             if test:
                 print(A, p)
                 Nenner = abs(p).T @ abs(A) @ abs(p)
@@ -44,7 +44,7 @@ def ldlup(L, d, j, g):
                     indef1 = 0
                 else:
                     indef1 = (p.T @ A @ p) / Nenner
-                disp("leave ldlup at 1")
+                print("leave ldlup at 1")
             return L, d, p
         w = g[K] / del_
         L[j, I] = v.T

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -182,7 +182,8 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 print("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             else:
                 # Changed by SW
-                print("iteration limit exceeded")
+                if prt:
+                    print("iteration limit exceeded")
             ier = 99
             break
 


### PR DESCRIPTION
This block of code is just now being hit in our python testing. 
1. `p` needs to be `n x 1`, not a one-dimensional item
2. Also, there was a matlab `disp` instead of a python `print` for when `test=1`

To clean up the display, the matlab minqsw doesn't print "iteration limit exceeded". See [here](https://github.com/POptUS/MINQ/blob/7f493287bd0206b16fe63e45f478b9488278ab53/m/minq5/minqsw.m#L152).  The python will display this message, only if `prt >0`.