### PR TITLE
Avoiding matrix subclass if G isn't sparse

### DIFF
--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -270,6 +270,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                     if prt > 1 and not free[k]:
                         print("unfixstep ", x[k], alp)
                     x[k] = xnew
+
                     g = g + alp * q
                     free[k] = 1
         # end of coordinate search
@@ -312,6 +313,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
             # no free variables - no subspace step taken
             if prt > 0:
                 print("no free variables - no subspace step taken")
+
             unfix = 1
         else:
             ######################
@@ -386,6 +388,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 oo = (xo[ind] - x[ind]) / pp
                 uu = (xu[ind] - x[ind]) / pp
 
+                # alpu = np.max(np.vstack((oo[pp < 0], uu[pp > 0], -np.inf)))
                 alpu = -np.inf
                 if len(oo[pp < 0]):
                     tmp = np.max(oo[pp < 0])
@@ -394,6 +397,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                     tmp = np.max(uu[pp > 0])
                     alpu = max(tmp, alpu)
 
+                # alpo = np.min(np.vstack((oo[pp > 0], uu[pp < 0], np.inf)))
                 alpo = np.inf
                 if len(oo[pp > 0]):
                     tmp = np.min(oo[pp > 0])

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -97,9 +97,14 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
 
     if xx is None:
         # cold start with absolutely smallest feasible point
-        xx = np.zeros(n)
+        xx = np.zeros((n, 1))
 
     # force starting point into the box
+    xx = np.asarray(xx)
+    if xx.ndim == 1:
+        xx = xx.reshape((n, 1))
+    elif xx.ndim == 2 and xx.shape == (1, n):
+        xx = xx.T
     xx = np.maximum(xu, np.minimum(xx, xo))
 
     # regularization for low rank problems
@@ -137,7 +142,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
         if np.linalg.norm(xx, np.inf) == np.inf:
             sys.exit("infinite xx in minq.m")
 
-        g = G * xx + c
+        g = G @ xx + c
         fctnew = gam + 0.5 * xx.T @ (c + g)
         if not improvement:
             # good termination
@@ -208,12 +213,12 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 # complete sweep performed without fixing a new active bound
                 break
 
-            q = G[:, k]
+            q = G[:, [k]]
             alpu = xu[k] - x[k]
             alpo = xo[k] - x[k]  # bounds on step
 
             # find step size
-            [alp, lba, uba, ier] = getalp(alpu, alpo, g[k][0, 0], q[k][0, 0])
+            [alp, lba, uba, ier] = getalp(alpu, alpo, np.asarray(g[k]).ravel()[0], np.asarray(q[k]).ravel()[0])
             if ier:
                 x = np.zeros((n, 1))
                 if lba:
@@ -278,7 +283,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
         if unfix and nfree_old == nfree:
             # in exact arithmetic, we are already optimal
             # recompute gradient for iterative refinement
-            g = G * x + c
+            g = G @ x + c
             nitref = nitref + 1
             if prt > 0:
                 print("optimum found; iterative refinement tried")
@@ -341,7 +346,12 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 # later: speed up the following by passing K to ldlup.m!
                 p = np.zeros((n, 1))
                 if n > 1:
-                    p[K] = G[np.nonzero(K)[0], j]
+                    idxK = np.nonzero(K)[0]
+                    if idxK.size:
+                        tmp = G[idxK, [j]]
+                        if sp.sparse.issparse(tmp):
+                            tmp = tmp.toarray()
+                        p[K] = np.asarray(tmp).reshape((-1, 1))
                 p[j] = G[j, j]
                 L, dd, p = ldlup(L.copy(), dd.copy(), j, p.copy())
                 definite = len(p) == 0

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -2,7 +2,6 @@ import sys
 
 import ipdb  # Only used when prt is > 2
 import numpy as np
-import scipy as sp
 from getalp import getalp
 from ldldown import ldldown
 from ldlup import ldlup
@@ -19,9 +18,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     %    s.t.   x in [xu,xo]    % xu<=xo is assumed
     % where G is a symmetric n x n matrix, not necessarily definite
     % (if G is indefinite, only a local minimum is found)
-    %
-    % if G is sparse, it is assumed that the ordering is such that
-    % a sparse modified Cholesky factorization is feasible
     %
     % prt	printlevel
     % xx	initial guess (optional)
@@ -43,7 +39,13 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     % Search for 'SW' to find specific lines
 
     % Translated from Matlab to Python by Jeffrey Larson, 2021
+
+    NOTE (simplified): This version assumes G is a *dense* numpy array.
+    All sparse-handling logic has been removed.
     """
+    # Force dense array early
+    G = np.asarray(G)
+
     c = np.atleast_2d(c).T
     xu = np.atleast_2d(xu).T
     xo = np.atleast_2d(xo).T
@@ -94,7 +96,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     nitrefmax = 3  # maximal number of iterative refinement steps
 
     # initialize trial point xx, function value fct and gradient g
-
     if xx is None:
         # cold start with absolutely smallest feasible point
         xx = np.zeros((n, 1))
@@ -109,14 +110,9 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
 
     # regularization for low rank problems
     hpeps = 100 * eps  # perturbation in last two digits
+    G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
-    if sp.sparse.issparse(G):
-        L = sp.sparse.eye(n)  # initialize LDL^T factorization of G_KK
-        G = G + sp.sparse.spdiags(hpeps * G.diagonal(), 0, n, n)
-    else:
-        # Avoids numpy.matrix subclass if G isn't dense.
-        L = np.eye(n)  # initialize LDL^T factorization of G_KK
-        G[np.diag_indices_from(G)] += hpeps * np.diag(G)
+    L = np.eye(n)  # initialize LDL^T factorization of G_KK
 
     K = np.full(n, False, bool)  # initially no rows in factorization
     dd = np.ones((n, 1))
@@ -243,6 +239,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                     max_diag_G = max(ddd)
 
                 return x, fct, ier, nsub
+
             xnew = x[k] + alp
             if prt and nitref > 0:
                 print(xnew, alp)
@@ -273,7 +270,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                     if prt > 1 and not free[k]:
                         print("unfixstep ", x[k], alp)
                     x[k] = xnew
-
                     g = g + alp * q
                     free[k] = 1
         # end of coordinate search
@@ -316,7 +312,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
             # no free variables - no subspace step taken
             if prt > 0:
                 print("no free variables - no subspace step taken")
-
             unfix = 1
         else:
             ######################
@@ -348,9 +343,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 if n > 1:
                     idxK = np.nonzero(K)[0]
                     if idxK.size:
-                        tmp = G[idxK, [j]]
-                        if sp.sparse.issparse(tmp):
-                            tmp = tmp.toarray()
+                        tmp = G[idxK, [j]]  # dense always
                         p[K] = np.asarray(tmp).reshape((-1, 1))
                 p[j] = G[j, j]
                 L, dd, p = ldlup(L.copy(), dd.copy(), j, p.copy())
@@ -393,7 +386,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 oo = (xo[ind] - x[ind]) / pp
                 uu = (xu[ind] - x[ind]) / pp
 
-                # alpu = np.max(np.vstack((oo[pp < 0], uu[pp > 0], -np.inf)))
                 alpu = -np.inf
                 if len(oo[pp < 0]):
                     tmp = np.max(oo[pp < 0])
@@ -402,7 +394,6 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                     tmp = np.max(uu[pp > 0])
                     alpu = max(tmp, alpu)
 
-                # alpo = np.min(np.vstack((oo[pp > 0], uu[pp < 0], np.inf)))
                 alpo = np.inf
                 if len(oo[pp > 0]):
                     tmp = np.min(oo[pp > 0])

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -2,6 +2,7 @@ import sys
 
 import ipdb  # Only used when prt is > 2
 import numpy as np
+import scipy as sp
 from getalp import getalp
 from ldldown import ldldown
 from ldlup import ldlup
@@ -43,6 +44,13 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     NOTE (simplified): This version assumes G is a *dense* numpy array.
     All sparse-handling logic has been removed.
     """
+    if sp.sparse.issparse(G):
+        raise NotImplementedError(
+            "The use of sparse matrices is not handled presently by minq in "
+            "Python.  Please use the MATLAB implementation of minq or contact "
+            "the POptUS team if you need support of sparse G in Python."
+        )
+
     # Force dense array early
     G = np.asarray(G)
 

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -104,7 +104,12 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
 
     # regularization for low rank problems
     hpeps = 100 * eps  # perturbation in last two digits
-    G = G + sp.sparse.spdiags(hpeps * np.diag(G), 0, n, n)
+
+    if sp.sparse.issparse(G):
+        G = G + sp.sparse.spdiags(hpeps * G.diagonal(), 0, n, n)
+    else:
+        # Avoids numpy.matrix subclass if G isn't dense.
+        G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
     # initialize LDL^T factorization of G_KK
     K = np.zeros(n, dtype=bool)  # initially no rows in factorization

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -44,6 +44,13 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     NOTE (simplified): This version assumes G is a *dense* numpy array.
     All sparse-handling logic has been removed.
     """
+    # Hardcoded values
+    EPS = np.finfo(float).eps  # Define machine epsilon
+
+    # Formatting
+    np.set_printoptions(precision=16, linewidth=150)
+
+    # Current limitations
     if sp.sparse.issparse(G):
         raise NotImplementedError(
             "The use of sparse matrices is not handled presently by minq in "
@@ -54,23 +61,27 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     # Force dense array early
     G = np.asarray(G)
 
-    c = np.atleast_2d(c).T
-    xu = np.atleast_2d(xu).T
-    xo = np.atleast_2d(xo).T
-
     # initialization
     convex = 0
     n = G.shape[0]
-    eps = np.finfo(float).eps  # Define machine epsilon
+
+    # We assume that vector arguments are objects that can be converted
+    # automatically to numpy arrays and are effectively 1D.
     if np.ndim(xu) == 1:
         xu = np.atleast_2d(xu).T
     if np.ndim(xo) == 1:
         xo = np.atleast_2d(xo).T
     if np.ndim(c) == 1:
         c = np.atleast_2d(c).T
+    if xx is None:
+        # cold start with absolutely smallest feasible point
+        xx = np.zeros((n, 1))
+    elif np.ndim(xx) == 1:
+        xx = np.atleast_2d(xx).T
 
-    np.set_printoptions(precision=16, linewidth=150)
     # check input data for consistency
+    #
+    # All vector arguments must be 2D column vectors at this point.
     ier = 0
     if G.shape[1] != n:
         ier = -1
@@ -87,10 +98,9 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     if xo.shape[0] != n or xo.shape[1] != 1:
         ier = -1
         print("minq: upper bound has wrong dimension")
-    if xx is not None:
-        if xx.shape[0] != n or xx.shape[1] != 1:
-            ier = -1
-            print("minq: starting point has wrong dimension")
+    if xx.shape[0] != n or xx.shape[1] != 1:
+        ier = -1
+        print("minq: starting point has wrong dimension")
     if ier == -1:
         x = np.full(n, np.nan, float)
         fct = np.nan
@@ -104,20 +114,12 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     nitrefmax = 3  # maximal number of iterative refinement steps
 
     # initialize trial point xx, function value fct and gradient g
-    if xx is None:
-        # cold start with absolutely smallest feasible point
-        xx = np.zeros((n, 1))
-
+    #
     # force starting point into the box
-    xx = np.asarray(xx)
-    if xx.ndim == 1:
-        xx = xx.reshape((n, 1))
-    elif xx.ndim == 2 and xx.shape == (1, n):
-        xx = xx.T
     xx = np.maximum(xu, np.minimum(xx, xo))
 
     # regularization for low rank problems
-    hpeps = 100 * eps  # perturbation in last two digits
+    hpeps = 100 * EPS  # perturbation in last two digits
     G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
     L = np.eye(n)  # initialize LDL^T factorization of G_KK
@@ -420,7 +422,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
                 # find step size
                 gTp = g.T @ p
                 agTp = abs(g).T @ abs(p)
-                if abs(gTp) < 100 * eps * agTp:
+                if abs(gTp) < 100 * EPS * agTp:
                     # linear term consists of roundoff only
                     gTp = 0
 

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -9,6 +9,16 @@ from ldlup import ldlup
 from pr01 import pr01
 
 
+def _check_nan_inf(name, x):
+    arr = np.asarray(x)
+
+    if np.isnan(arr).any():
+        raise ValueError(f"{name} contains NaN.")
+
+    if np.isinf(arr).any():
+        raise ValueError(f"{name} contains Inf.")
+
+
 def minqsw(gam, c, G, xu, xo, prt, xx=None):
     """
     % function [x,fct,ier,nsub]=minq(gam,c,G,xu,xo,prt,xx)
@@ -44,6 +54,15 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     NOTE (simplified): This version assumes G is a *dense* numpy array.
     All sparse-handling logic has been removed.
     """
+
+    _check_nan_inf("gam", gam)
+    _check_nan_inf("c", c)
+    _check_nan_inf("G", G)
+    _check_nan_inf("xu", xu)
+    _check_nan_inf("xo", xo)
+    if xx is not None:
+        _check_nan_inf("xx", xx)
+
     # Hardcoded values
     EPS = np.finfo(float).eps  # Define machine epsilon
 

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -9,7 +9,7 @@ from ldlup import ldlup
 from pr01 import pr01
 
 
-def _check_nan_inf(name, x):
+def _check_nan_inf(name, arr):
     if np.isnan(arr).any():
         raise ValueError(f"{name} contains NaN.")
 

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -113,7 +113,7 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
         L = np.eye(n)  # initialize LDL^T factorization of G_KK
         G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
-    K = np.zeros(n, dtype=bool)  # initially no rows in factorization
+    K = np.full(n, False, bool)  # initially no rows in factorization
     dd = np.ones((n, 1))
 
     # dummy initialization of indicator of free variables

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -51,17 +51,9 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
 
     % Translated from Matlab to Python by Jeffrey Larson, 2021
 
-    NOTE (simplified): This version assumes G is a *dense* numpy array.
+    NOTE (simplified): This version casts G to be a standard numpy array.
     All sparse-handling logic has been removed.
     """
-
-    _check_nan_inf("gam", gam)
-    _check_nan_inf("c", c)
-    _check_nan_inf("G", G)
-    _check_nan_inf("xu", xu)
-    _check_nan_inf("xo", xo)
-    if xx is not None:
-        _check_nan_inf("xx", xx)
 
     # Hardcoded values
     EPS = np.finfo(float).eps  # Define machine epsilon
@@ -99,7 +91,14 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
         xx = np.atleast_2d(xx).T
 
     # check input data for consistency
-    #
+    _check_nan_inf("gam", gam)
+    _check_nan_inf("c", c)
+    _check_nan_inf("G", G)
+    _check_nan_inf("xu", xu)
+    _check_nan_inf("xo", xo)
+    if xx is not None:
+        _check_nan_inf("xx", xx)
+
     # All vector arguments must be 2D column vectors at this point.
     ier = 0
     if G.shape[1] != n:

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -10,8 +10,6 @@ from pr01 import pr01
 
 
 def _check_nan_inf(name, x):
-    arr = np.asarray(x)
-
     if np.isnan(arr).any():
         raise ValueError(f"{name} contains NaN.")
 
@@ -44,15 +42,17 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     %
     function [x,fct,ier,nsub]=minqsw(gam,c,G,xu,xo,prt,xx)
 
-    % This is minq with changes to:
+    % This is MINQ with changes to:
     % 1) max number of iterations,
     % 2) display option for exceeding maxit
     % Search for 'SW' to find specific lines
 
     % Translated from Matlab to Python by Jeffrey Larson, 2021
 
-    NOTE (simplified): This version casts G to be a standard numpy array.
-    All sparse-handling logic has been removed.
+    NOTE (simplified): The use of sparse matrices is not handled presently by
+    MINQ in Python.  Please use the MATLAB implementation of MINQ if their use
+    if required or contact the POptUS team to request support of sparse G in
+    Python.
     """
 
     # Hardcoded values
@@ -64,9 +64,10 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     # Current limitations
     if sp.sparse.issparse(G):
         raise NotImplementedError(
-            "The use of sparse matrices is not handled presently by minq in "
-            "Python.  Please use the MATLAB implementation of minq or contact "
-            "the POptUS team if you need support of sparse G in Python."
+            "The use of sparse matrices is not handled presently by MINQ in "
+            "Python.  Please use the MATLAB implementation of MINQ if their "
+            "use is required or contact the POptUS team to request support "
+            "of sparse G in Python."
         )
 
     # Force dense array early
@@ -90,16 +91,16 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     elif np.ndim(xx) == 1:
         xx = np.atleast_2d(xx).T
 
-    # check input data for consistency
+    # check input data
     _check_nan_inf("gam", gam)
     _check_nan_inf("c", c)
     _check_nan_inf("G", G)
     _check_nan_inf("xu", xu)
     _check_nan_inf("xo", xo)
-    if xx is not None:
-        _check_nan_inf("xx", xx)
+    _check_nan_inf("xx", xx)
 
-    # All vector arguments must be 2D column vectors at this point.
+    # All vector arguments must be 2D column vectors at this point with
+    # consistent shapes/sizes.
     ier = 0
     if G.shape[1] != n:
         ier = -1

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -102,16 +102,15 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     # force starting point into the box
     xx = np.maximum(xu, np.minimum(xx, xo))
 
-    # regularization for low rank problems & initialize LDL^T factorization of
-    # G_KK
+    # regularization for low rank problems
     hpeps = 100 * eps  # perturbation in last two digits
 
     if sp.sparse.issparse(G):
-        L = sp.sparse.eye(n)
+        L = sp.sparse.eye(n)  # initialize LDL^T factorization of G_KK
         G = G + sp.sparse.spdiags(hpeps * G.diagonal(), 0, n, n)
     else:
         # Avoids numpy.matrix subclass if G isn't dense.
-        L = np.eye(n)
+        L = np.eye(n)  # initialize LDL^T factorization of G_KK
         G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
     K = np.zeros(n, dtype=bool)  # initially no rows in factorization

--- a/py/minq5/minqsw.py
+++ b/py/minq5/minqsw.py
@@ -102,21 +102,19 @@ def minqsw(gam, c, G, xu, xo, prt, xx=None):
     # force starting point into the box
     xx = np.maximum(xu, np.minimum(xx, xo))
 
-    # regularization for low rank problems
+    # regularization for low rank problems & initialize LDL^T factorization of
+    # G_KK
     hpeps = 100 * eps  # perturbation in last two digits
 
     if sp.sparse.issparse(G):
+        L = sp.sparse.eye(n)
         G = G + sp.sparse.spdiags(hpeps * G.diagonal(), 0, n, n)
     else:
         # Avoids numpy.matrix subclass if G isn't dense.
+        L = np.eye(n)
         G[np.diag_indices_from(G)] += hpeps * np.diag(G)
 
-    # initialize LDL^T factorization of G_KK
     K = np.zeros(n, dtype=bool)  # initially no rows in factorization
-    if sp.sparse.issparse(G):
-        L = sp.sparse.eye(n)
-    else:
-        L = np.eye(n)
     dd = np.ones((n, 1))
 
     # dummy initialization of indicator of free variables


### PR DESCRIPTION
`scipy.sparse.spdiags` returns a sparse matrix object. When we add that to `G`, the result follows SciPy’s sparse matrix type rules. This can promote results to a `numpy.matrix` instead of a regular `numpy.ndarray`.

If someone has a `G` that is sparse, then they can still maintain the sparse form. Otherwise, we can avoid the `matrix` subclass.